### PR TITLE
fixed reset script argument; clearer prompt

### DIFF
--- a/scripts/new_request.sh
+++ b/scripts/new_request.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-[[ -z "$1" ]] && echo "Expected syntax: $0 YOUR_TESTNET_ACCOUNT_ID" >&2 && exit 1
+[[ -z "$1" ]] && echo "Expected syntax: $0 YOUR_REQUESTER_ID" >&2 && exit 1
 
 JSON="{\"sources\": [],\"tags\":[\"sports\",\"nfl\"],\"description\":\"Which team won the NFL Super Bowl in 1996?\",\"outcomes\":[\"Cowboys\",\"Steelers\"],\"challenge_period\":\"120000000000\",\"settlement_time\":\"1\",\"data_type\":\"String\",\"creator\":\"your_account_id.flux-dev\"}"
 env NEAR_ENV=testnet near call $1 create_data_request "{\"amount\": \"1000000000000000000000000\", \"payload\": $JSON}" --accountId $1 --amount 0.000000000000000000000001 --gas=300000000000000

--- a/scripts/reset_account.sh
+++ b/scripts/reset_account.sh
@@ -2,7 +2,7 @@
 
 # default params
 network=${network:-testnet}
-account=${accountId:-flux-dev}
+accountId=${accountId:-flux-dev}
 master=${master:-flux-dev}
 initialBalance=${initialBalance:-5}
 
@@ -17,5 +17,5 @@ while [ $# -gt 0 ]; do
   shift
 done
 
-NEAR_ENV=$network near delete $account $master
-NEAR_ENV=$network near create-account $account --masterAccount $master --initialBalance $initialBalance
+NEAR_ENV=$network near delete $accountId $master
+NEAR_ENV=$network near create-account $accountId --masterAccount $master --initialBalance $initialBalance


### PR DESCRIPTION
Hello Flux Devs!

I just tried the reset script and found that the `account` argument wasn't picked up properly by the script, hence this fix proposal.

Reproduction:
- invoke `./script/reset_account.sh --account foo --master bar`
- verify that only `bar` gets assigned to`$master`, meanwhile `$account` remains at the default value `flux-dev`
- expected: `$account` has the value `foo`

The fix was simply to use `accountId` all over the script, therefore assigning the correct value to the variable. The reason `accountId` is preferred over `account` is purely because the former value is also used in other scripts, for example `deploy_requester.sh`

---

Miscellaneous: the other bit of this PR is a tiny reword of a cli prompt, and should be self-explanatory.

Thank you for your time reviewing!