### PR TITLE
Updated cli prompt for get_request.sh script

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,23 @@ bash scripts/deploy_requester.sh --accountId $REQUESTER
 bash scripts/reset_account.sh --master $ACCOUNT --account $REQUESTER
 ```
 
+## Sending your 1st request
+
+```bash
+# set vars
+REQUESTER=requester.account.testnet
+
+# send an example arbitrator request at the requester contract that you just deployed
+sh scripts/new_request.sh $REQUESTER
+
+# retrieve the details of the request that you just created (request at index 0)
+sh scripts/get_request.sh $REQUESTER 0
+
+# once you've sent more requests, you can call the `get_request` script with the
+# exact index number you're interested in to view the details of the request at
+# that specific index
+```
+
 ## Options
 
 ### Whitelist

--- a/scripts/get_request.sh
+++ b/scripts/get_request.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-[[ -z "$1" ]] && echo "Expected syntax: $0 YOUR_TESTNET_ACCOUNT_ID YOUR_REQUEST_NONCE" >&2 && exit 1
-[[ -z "$2" ]] && echo "Expected syntax: $0 YOUR_TESTNET_ACCOUNT_ID YOUR_REQUEST_NONCE" >&2 && exit 1
+[[ -z "$1" ]] && echo "Expected syntax: $0 YOUR_REQUESTER_ID YOUR_REQUEST_ID" >&2 && exit 1
+[[ -z "$2" ]] && echo "Expected syntax: $0 YOUR_REQUESTER_ID YOUR_REQUEST_ID" >&2 && exit 1
 
 near call $1 get_data_request "{\"request_id\": \"$2\"}" --accountId $1


### PR DESCRIPTION
Hello Flux Devs,

Now that the request script doesn't need the `nonce` anymore, we probably can update the cli prompt so that it's not confusing for users (esp. new users).

I also wish to propose a few example script snippets in the README.

Thanks for your time reviewing!