### PR TITLE
Feat/withdraw_validity_bond method for data request creator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,8 +159,8 @@ dependencies = [
 
 [[package]]
 name = "flux-sdk"
-version = "0.2.3"
-source = "git+https://github.com/fluxprotocol/flux-sdk-rs.git?rev=aadde819566bc5306e6f17a9e61cba3f895dfb90#aadde819566bc5306e6f17a9e61cba3f895dfb90"
+version = "0.2.4"
+source = "git+https://github.com/fluxprotocol/flux-sdk-rs.git?rev=433b3297eaac4600b8c8a8bb2673081480379511#433b3297eaac4600b8c8a8bb2673081480379511"
 dependencies = [
  "near-sdk",
  "serde",
@@ -473,7 +473,7 @@ checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
 name = "request-interface"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "flux-sdk",
  "near-sdk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "request-interface"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Flux Contributors <contributors@flux.xyz>"]
 edition = "2018"
 
@@ -9,5 +9,5 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 near-sdk = "3.1.0"
-flux-sdk = { git = "https://github.com/fluxprotocol/flux-sdk-rs.git", rev="aadde819566bc5306e6f17a9e61cba3f895dfb90" }
+flux-sdk = { git = "https://github.com/fluxprotocol/flux-sdk-rs.git", rev="433b3297eaac4600b8c8a8bb2673081480379511" }
 serde = "1.0.118"


### PR DESCRIPTION
- added two new fields to `DataRequestDetails` in flux-sdk: `creator` and `has_withdrawn_validity_bond`  
- created method for data request creators to get their validity bond back by calling `withdraw_validity_bond(request_id)`. this method asserts the caller matches the creator, the validity bond has not already been withdrawn, and that the data request is finalized

closes #11 